### PR TITLE
Add query parameter support for contact page

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -12,6 +12,7 @@ import Footer from '@components/Footer.astro';
 <html lang="en" class="bg-gray-200 dark:bg-gray-900 text-black dark:text-white">
     <head>
         <Meta title={`${frontmatter.title} | Nebula's Blog`} description={frontmatter.description} />
+        <slot name="head" />
     </head>
 
     <body class="p-[50px]">

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -15,6 +15,7 @@ import Footer from '@components/Footer.astro';
 <html lang="en" class="bg-gray-200 dark:bg-gray-900 text-black dark:text-white">
     <head>
         <Meta title={title || "DisPaisy"} />
+        <slot name="head" />
     </head>
 
     <body class="p-[50px]">

--- a/src/layouts/Light.astro
+++ b/src/layouts/Light.astro
@@ -15,6 +15,7 @@ import Footer from '@components/Footer.astro';
 <html lang="en" class="bg-white text-black">
     <head>
         <Meta title={title || "DisPaisy"} />
+        <slot name="head" />
     </head>
 
     <body class="p-[50px]">

--- a/src/pages/stolenorfotgot/devices.astro
+++ b/src/pages/stolenorfotgot/devices.astro
@@ -1,0 +1,57 @@
+---
+import Layout from '@layouts/Default.astro';
+---
+
+<meta slot="head" name="robots" content="noindex,nofollow" />
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const params = new URLSearchParams(window.location.search);
+        const device = params.get('device');
+        const geo = params.get('geo');
+
+        if (!device) {
+            const container = document.getElementById('content');
+            if (container) container.remove();
+            return;
+        }
+
+        document.getElementById('device-name-en').textContent = device;
+        document.getElementById('device-name-it').textContent = device;
+
+        const geoEn = document.getElementById('geo-en');
+        const geoIt = document.getElementById('geo-it');
+
+        if (geo === 'on') {
+            geoEn.textContent = 'This device is geolocated 24/7';
+            geoIt.textContent = 'Il dispositivo è geolocalizzato 24/7';
+        } else if (geo === 'on-ish') {
+            geoEn.textContent = 'This device is geolocated';
+            geoIt.textContent = 'Questo dispositivo è geolocalizzato';
+        }
+    });
+
+    const switchToIt = () => {
+        document.getElementById('lang-en').classList.add('hidden');
+        document.getElementById('lang-it').classList.remove('hidden');
+    };
+    const switchToEn = () => {
+        document.getElementById('lang-it').classList.add('hidden');
+        document.getElementById('lang-en').classList.remove('hidden');
+    };
+</script>
+
+<Layout title="Lost or Stolen Device">
+    <div id="content" class="prose dark:prose-dark">
+        <h1>Lost or Stolen Device</h1>
+        <div id="lang-en">
+            <p>If you have found <span id="device-name-en"></span>, please contact me at <a href="mailto:dis@paisy.lol">dis@paisy.lol</a> or WhatsApp <a href="https://wa.me/393509683948">+393509683948</a>.</p>
+            <p id="geo-en"></p>
+            <button onclick="switchToIt()" class="mt-4 px-4 py-2 bg-blue-600 text-white rounded">🇮🇹</button>
+        </div>
+        <div id="lang-it" class="hidden">
+            <p>Se hai trovato <span id="device-name-it"></span>, contattami via email a <a href="mailto:dis@paisy.lol">dis@paisy.lol</a> oppure su WhatsApp <a href="https://wa.me/393509683948">+393509683948</a>.</p>
+            <p id="geo-it"></p>
+            <button onclick="switchToEn()" class="mt-4 px-4 py-2 bg-blue-600 text-white rounded">🏴</button>
+        </div>
+    </div>
+</Layout>


### PR DESCRIPTION
## Summary
- update the hidden contact page so it reads `device` and `geo` query parameters
- show geolocation messages for `geo=on` or `geo=on-ish`
- use emoji buttons to toggle English and Italian text
- page now hides when `device` is missing

## Testing
- `npm run build` *(fails: astro not found)*